### PR TITLE
Install by default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Install script for Findsploit by 1N3@CrowdShield
-# https://crowdshield.com 
+# https://crowdshield.com
 #
 
 FINDSPLOIT_INSTALL_DIR=/usr/share/findsploit
@@ -24,9 +24,9 @@ echo -e "$RESET"
 echo -e "$OKGREEN + -- --=[This script will install findsploit under $FINDSPLOIT_INSTALL_DIR."
 rm -Rf $FINDSPLOIT_INSTALL_DIR 2> /dev/null
 mkdir -p $FINDSPLOIT_INSTALL_DIR 2> /dev/null
-cp -Rf $PWD/* $FINDSPLOIT_INSTALL_DIR 
+cp -Rf $PWD/* $FINDSPLOIT_INSTALL_DIR
 cd $FINDSPLOIT_INSTALL_DIR
-apt-get install exploitdb xdg-utils
+apt-get install -y exploitdb xdg-utils
 mkdir loot 2> /dev/null
 chmod +x $FINDSPLOIT_INSTALL_DIR/findsploit
 chmod +x $FINDSPLOIT_INSTALL_DIR/copysploit


### PR DESCRIPTION
I'm creating a docker to run findsploit, therefore the `./install.sh` needs to be unattended, so I need to use the flag `-y` in the `apt-get` command.

Hope it's ok for you